### PR TITLE
issue-69 adding meta tag so index is not cached by browsers

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -5,8 +5,7 @@
         <title>GNV Permit Locator</title>
         <meta charset="UTF-8">
         <meta name="viewport" content="width=device-width, initial-scale=1">
-        <!-- Polyfill(s) for older browsers -->
-        <script src="./node_modules/core-js/client/shim.min.js"></script>
+        <meta http-equiv="expires" content="0">
     </head>
     <body>
         <my-app>Loading...</my-app>


### PR DESCRIPTION
Completes issue #69 and #65.

Changes in this pull request:

- Added meta tag to index so it is not cached
- Removed reference to shim file in node_modules to resolve 404...if we want to use this it will have to be loaded differently (probably via an import somewhere because of webpack)

