### PR TITLE
issue-136

### DIFF
--- a/app/app.routes.ts
+++ b/app/app.routes.ts
@@ -26,4 +26,4 @@ const routes: Routes = [
 ];
 
 export const appRoutingProviders: any[] = [];
-export const routing = RouterModule.forRoot(routes);
+export const routing = RouterModule.forRoot(routes, { useHash: true });


### PR DESCRIPTION
Use hash location strategy as described here
https://angular.io/docs/ts/latest/guide/router.html#!#-hashlocationstrategy-
This allows us to host the site on S3 without needing strange redirect
rules at the S3 level

Completes issue #136  .

Changes in this pull request:

- use hash location strategy for routing