### PR TITLE
issue: #156 remove toggling business types list on click

### DIFF
--- a/app/components/businessType-list.component.css
+++ b/app/components/businessType-list.component.css
@@ -120,7 +120,6 @@ a.bp-permit-name {
     color: #7b7b7b;
 }
 .business-type-title {
-    cursor: pointer;
     position: relative;
 }
 .business-type-title.collapsed::after {

--- a/app/components/businessType-list.component.html
+++ b/app/components/businessType-list.component.html
@@ -3,10 +3,9 @@
     <div class="row">
         <div class="col-md-4 selected-business-type-column">
             <div class="bp-list-type-header">REFINE YOUR RESULTS</div>
-            <div class="bp-list-type-title bp-list-type-subheader no-select" (click)="onClickTogglebusinessTypes(); $event.stopPropagation();" [class.selected]="togglebusinessTypes">Business Types <i class="bp-type-title-icon fa" [ngClass]="{'fa-plus-circle': !togglebusinessTypes, 'fa-minus-circle': togglebusinessTypes}"></i>
-            </div>
+            <div class="bp-list-type-title bp-list-type-subheader">Business Types</div>
             <!-- All the business types -->
-            <div *ngIf="displayedTypes && togglebusinessTypes">
+            <div *ngIf="displayedTypes">
 
                 <!-- Each Selected Business Type-->
                 <ul class="bp-list-types">

--- a/app/components/businessType-list.component.ts
+++ b/app/components/businessType-list.component.ts
@@ -50,7 +50,6 @@ export class BusinessTypeListComponent implements OnInit {
     conditionalPermitsToShowSet: Set<Permit> = new Set<Permit>();
     conditionalPermitsToShow: Permit[] = [];
     toggleAllBusinessTypes: boolean = true;
-    togglebusinessTypes: boolean =  true;
     toggleSelectedBusinesstype: boolean = false;
     requiredAllBusinessPermits: Permit[] = [];
     conditionalAllBusinessPermits: Permit[] = [];
@@ -125,9 +124,6 @@ export class BusinessTypeListComponent implements OnInit {
                 /* onComplete */
                 this.isLoading = false;
             });
-    }
-    onClickTogglebusinessTypes(): void {
-        this.togglebusinessTypes = !this.togglebusinessTypes;
     }
     onSelectBusinessType(selectedBusinessType: BusinessType): void {
         this.toggleAllBusinessTypes = false;


### PR DESCRIPTION
This removes the ability to toggle the business types list by clicking the
title. This functionality is not needed

Closes #156