### PR TITLE
issue: 173 Mobile footer be less bad

### DIFF
--- a/app/components/landing/landing.component.css
+++ b/app/components/landing/landing.component.css
@@ -1,3 +1,10 @@
 .container-landing {
     text-align: center;
 }
+
+@media (max-width: 600px) {
+  .container-landing img {
+    height: auto;
+    width: 100%;
+  }
+}

--- a/app/footer.css
+++ b/app/footer.css
@@ -41,3 +41,13 @@
     font-size: 2em;
     margin-right: .5em;
 }
+
+@media (max-width: 600px) {
+  .footer-wrap {
+    display: block;
+  }
+  .footer-section, .footer-section-large {
+      width: 100%;
+      margin: 0;
+  }
+}


### PR DESCRIPTION
Completes issue #173 Mobile footer be less bad .

Changes in this pull request:

- Footer sections go full width on phones
- Also made landing image stretch on phone to not have weird horizontal scrolling

<img width="512" alt="screen shot 2017-05-16 at 8 45 49 pm" src="https://cloud.githubusercontent.com/assets/51855/26133966/29e0b490-3a79-11e7-832f-2d6eb927584d.png">
