### PR TITLE
issue: 193 cursor becomes a pointer when hovering over navbar items

### DIFF
--- a/app/components/search.component.css
+++ b/app/components/search.component.css
@@ -27,6 +27,9 @@
 .navbar-nav .nav-item.pull-right {
     float: right;
 }
+.navbar-nav .nav-item {
+    cursor: pointer;
+}
 .page-header, .bp-header {
     margin: 0;
     padding: 0px 0px 20px 0px;


### PR DESCRIPTION
cursor becomes a pointer when hovering over navbar items inlcuding icon, text, and whitespace.

Completes issue # .193

Changes in this pull request:

- added css rule for `.navbar-nav .nav-item` which changes cursor to pointer.